### PR TITLE
Add painel screen for grouped management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'screens/marcas_screen.dart';
+import 'screens/painel_screen.dart';
 
 void main() {
   runApp(const JPApp());
@@ -13,7 +13,7 @@ class JPApp extends StatelessWidget {
     return MaterialApp(
       title: 'JP Peças',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: const MarcasScreen(),
+      home: const PainelScreen(),
     );
   }
 }

--- a/lib/screens/painel_screen.dart
+++ b/lib/screens/painel_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'placeholder_screen.dart';
+
+class PainelScreen extends StatelessWidget {
+  const PainelScreen({super.key});
+
+  Widget _grupo(BuildContext context, String titulo) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          titulo,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => PlaceholderScreen(title: 'Cadastrar $titulo')),
+                );
+              },
+              child: const Text('Cadastrar'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => PlaceholderScreen(title: 'Gerenciar $titulo')),
+                );
+              },
+              child: const Text('Gerenciar'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gerenciamento de Produtos')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _grupo(context, 'Marca'),
+            _grupo(context, 'Modelo'),
+            _grupo(context, 'Tipo'),
+            _grupo(context, 'Produto'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/placeholder_screen.dart
+++ b/lib/screens/placeholder_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class PlaceholderScreen extends StatelessWidget {
+  final String title;
+  const PlaceholderScreen({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: const Center(
+        child: Text('Funcionalidade em construção'),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,8 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jppecas_app/main.dart';
 
 void main() {
-  testWidgets('App loads marcas screen', (WidgetTester tester) async {
+  testWidgets('App loads painel screen', (WidgetTester tester) async {
     await tester.pumpWidget(const JPApp());
-    expect(find.text('JP Peças'), findsOneWidget);
+    expect(find.text('Gerenciamento de Produtos'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement a new `PainelScreen` grouping actions for Marca, Modelo, Tipo and Produto
- show placeholder pages for each action
- update entry point to use the new panel
- adjust widget test for new home screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782e4e0040832cb66d5fd319d6262a